### PR TITLE
tweaks

### DIFF
--- a/Project/ddrawwrapper/DirectDrawSurfaceWrapper.cpp
+++ b/Project/ddrawwrapper/DirectDrawSurfaceWrapper.cpp
@@ -1647,15 +1647,15 @@ HRESULT IDirectDrawSurfaceWrapper::WrapperInitialize(LPDDSURFACEDESC lpDDSurface
 
 	//Overallocate the memory to prevent access outside of memory range by the exe
 	//if(!ReInitialize(displayWidth, displayHeight)) return DDERR_OUTOFMEMORY;
-	//maximum supported resolution is 1920x1440
-	rawVideoMem = new BYTE[1920 * 1440];
+	//maximum supported resolution is 2560x1440
+	rawVideoMem = new BYTE[2560 * 1440];
 	if(rawVideoMem == NULL)
 	{
 		debugMessage(0, "IDirectDrawSurfaceWrapper::WrapperInitialize", "Failed to allocate raw video memory");
 		return DDERR_OUTOFMEMORY;
 	}
 	// Clear raw memory
-	ZeroMemory(rawVideoMem, 1920 * 1440 * sizeof(BYTE));
+	ZeroMemory(rawVideoMem, 2560 * 1440 * sizeof(BYTE));
 
 	// Allocate virtual video memory RGB
 	rgbVideoMem = new UINT32[surfaceWidth * surfaceHeight];

--- a/Project/ddrawwrapper/DirectDrawWrapper.cpp
+++ b/Project/ddrawwrapper/DirectDrawWrapper.cpp
@@ -1024,8 +1024,8 @@ IDirectDrawWrapper::IDirectDrawWrapper()
 	inMenu = false;
 	curMenu = 0;
     // Resolutions
-	windowedResolutions = new POINT[10];
-	windowedResolutionCount = 10;
+	windowedResolutions = new POINT[11];
+	windowedResolutionCount = 11;
 	windowedResolutions[0].x = 640;
 	windowedResolutions[0].y = 480;
 	windowedResolutions[1].x = 800;
@@ -1046,6 +1046,8 @@ IDirectDrawWrapper::IDirectDrawWrapper()
 	windowedResolutions[8].y = 1200;
 	windowedResolutions[9].x = 1920;
 	windowedResolutions[9].y = 1440;
+	windowedResolutions[10].x = 2560;
+	windowedResolutions[10].y = 1440;
 
 	fullscreenResolutionCount = 0;
 	fullscreenResolutions = NULL;
@@ -1878,7 +1880,7 @@ bool IDirectDrawWrapper::CreateD3DDevice()
 		}
 
 		// No modes above maximum size
-		if(d3ddispmode.Width < 1920 && d3ddispmode.Height < 1440) {
+		if(d3ddispmode.Width <= 2560 && d3ddispmode.Height <= 1440) {
 			fullscreenResolutions[fullscreenResolutionCount].x = d3ddispmode.Width;
 			fullscreenResolutions[fullscreenResolutionCount].y = d3ddispmode.Height;
 			fullscreenRefreshes[fullscreenResolutionCount] = d3ddispmode.RefreshRate;


### PR DESCRIPTION
* Expands max supported resolution from 1920x1440 to 2560x1440 and adds 2560x1440 to resolution list
* Fixes a bug where max supported resolution wasn't listed in fullscreen resolutions because of a `<` instead of `<=` check
* Fixes a bug where fullscreen basically only worked properly at 640x480 resolution, on anything bigger the cursor was free to leave the game area